### PR TITLE
Video

### DIFF
--- a/resources/language/resource.language.en_GB/strings.po
+++ b/resources/language/resource.language.en_GB/strings.po
@@ -40,7 +40,11 @@ msgctxt "#30005"
 msgid "Confirm Love/Ban submissions"
 msgstr ""
 
-#empty strings from id 30006 to 32010
+msgctxt "#30006"
+msgid "Submit music videos to Last.fm"
+msgstr ""
+
+#empty strings from id 30007 to 32010
 
 msgctxt "#32011"
 msgid "Last.fm"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,6 +2,7 @@
 <settings>
 	<category label="30000">
 		<setting id="lastfmsubmitsongs" type="bool" label="30001" default="true"/>
+		<setting id="lastfmsubmitvideos" type="bool" label="30006" default="false"/>
 		<setting id="lastfmsubmitradio" type="bool" label="30002" default="false"/>
 		<setting id="lastfmuser" type="text" label="30003" default=""/>
 		<setting id="lastfmpass" type="text" label="30004" default="" option="hidden"/>

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -277,6 +277,7 @@ class MyPlayer(xbmc.Player):
         else:
             user = '0'
         log('song scrobbling enabled: ' + str(self.songs), SESSION)
+        log('video scrobbling enabled: ' + str(self.videos), SESSION)
         log('radio scrobbling enabled: ' + str(self.radio), SESSION)
         log('artist: ' + artist, SESSION)
         log('title: ' + title, SESSION)
@@ -308,6 +309,10 @@ class MyPlayer(xbmc.Player):
             elif user == '0' and not self.radio:
                 # user is listening to remote source, but the radio setting is disabled
                 log('user settings prohibit us from scrobbling online streaming radio', SESSION)
+                return None
+            elif self.isPlayingMusicVideo() and not self.videos:
+                # user is watching a music video, but the music video setting is disabled
+                log('user settings prohibit us from scrobbling music videos', SESSION)
                 return None
             # previous clauses did not return, so we have either a local play with the songs setting enabled, or a remote play with the radio setting enabled,
             # and therefore can scrobble

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -310,6 +310,9 @@ class MyPlayer(xbmc.Player):
             log('cannot scrobble track with no artist and track information', SESSION)
             return None
 
+    def isPlayingMusicVideo( self ):
+        return self.isPlayingVideo() and self.getVideoInfoTag().getMediaType() == 'musicvideo'
+
 class MyMonitor(xbmc.Monitor):
     def __init__( self, *args, **kwargs ):
         xbmc.Monitor.__init__( self )

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -250,10 +250,16 @@ class MyPlayer(xbmc.Player):
 
     def _get_tags( self ):
         # get track tags
-        tags = self.getMusicInfoTag()
-        artist = tags.getArtist().decode("utf-8")
+        if self.isPlayingAudio():
+            tags = self.getMusicInfoTag()
+            artist = tags.getArtist().decode("utf-8")
+            albumartist = tags.getAlbumArtist().decode("utf-8")
+        elif self.isPlayingVideo():
+            tags = self.getVideoInfoTag()
+            artist = tags.getArtist()[0].decode("utf-8")
+            albumartist = ""  # not available for music videos.
+
         album = tags.getAlbum().decode("utf-8")
-        albumartist = tags.getAlbumArtist().decode("utf-8")
         title = tags.getTitle().decode("utf-8")
         duration = str(tags.getDuration())
         # get duration from xbmc.Player if the MusicInfoTag duration is invalid

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -215,20 +215,22 @@ class MyPlayer(xbmc.Player):
 
     def onPlayBackStarted( self ):
         # only do something if we're playing audio and user has enabled it in settings
-        if self.isPlayingAudio() and self.sesskey and self.user and self.pwd and (self.radio or self.songs):
-            # we need to keep track of this bool for stopped/ended notifications
-            self.Audio = True
-            log('onPlayBackStarted', SESSION)
-            # tags are not available instantly and we don't what to announce right away as the user might be skipping through the songs
-            xbmc.sleep(500)
-            # don't announce if the user already skipped to the next track or stopped playing audio
-            if self.isPlayingAudio():
-                # get tags
-                tags = self._get_tags()
-                # check if we have anything to submit
-                if tags:
-                    # announce song
-                     self.action(tags)
+
+        if self.sesskey and self.user and self.pwd:
+            if (self.isPlayingAudio() and (self.radio or self.songs)) or (self.isPlayingMusicVideo() and self.videos):
+                # we need to keep track of this bool for stopped/ended notifications
+                self.Audio = True
+                log('onPlayBackStarted', SESSION)
+                # tags are not available instantly and we don't what to announce right away as the user might be skipping through the songs
+                xbmc.sleep(500)
+                # don't announce if the user already skipped to the next track or stopped playing audio
+                if self.isPlayingAudio() or self.isPlayingMusicVideo():
+                    # get tags
+                    tags = self._get_tags()
+                    # check if we have anything to submit
+                    if tags:
+                        # announce song
+                         self.action(tags)
 
     def onPlayBackEnded( self ):
         # ignore onPlayBackEnded notifications from the video player

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -248,15 +248,16 @@ class MyPlayer(xbmc.Player):
 
     def _get_tags( self ):
         # get track tags
-        artist = self.getMusicInfoTag().getArtist().decode("utf-8")
-        album = self.getMusicInfoTag().getAlbum().decode("utf-8")
-        albumartist = self.getMusicInfoTag().getAlbumArtist().decode("utf-8")
-        title = self.getMusicInfoTag().getTitle().decode("utf-8")
-        duration = str(self.getMusicInfoTag().getDuration())
+        tags = self.getMusicInfoTag()
+        artist = tags.getArtist().decode("utf-8")
+        album = tags.getAlbum().decode("utf-8")
+        albumartist = tags.getAlbumArtist().decode("utf-8")
+        title = tags.getTitle().decode("utf-8")
+        duration = str(tags.getDuration())
         # get duration from xbmc.Player if the MusicInfoTag duration is invalid
         if int(duration) <= 0:
             duration = str(int(self.getTotalTime()))
-        track    = str(self.getMusicInfoTag().getTrack())
+        track    = str(tags.getTrack())
         mbid     = '' # musicbrainz id is not yet available
         streamid = '' # deprecated
         path      = self.getPlayingFile().decode("utf-8")

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -54,10 +54,11 @@ class Main:
         user         = settings['user']
         pwd          = settings['pwd']
         songs        = settings['songs']
+        videos       = settings['videos']
         radio        = settings['radio']
         self.sesskey = settings['sesskey']
         # init the player class (re-init when settings have changed)
-        self.player = MyPlayer(action=self._lastfm_submit, user=user, pwd=pwd, songs=songs, radio=radio, sesskey=self.sesskey)
+        self.player = MyPlayer(action=self._lastfm_submit, user=user, pwd=pwd, songs=songs, videos=videos, radio=radio, sesskey=self.sesskey)
         # init the player class (re-init when settings have changed)
         self.monitor = MyMonitor(action=self._get_settings, user=user, pwd=pwd)
 
@@ -208,6 +209,7 @@ class MyPlayer(xbmc.Player):
         self.pwd     = kwargs['pwd']
         self.sesskey = kwargs['sesskey']
         self.songs   = kwargs['songs']
+        self.videos  = kwargs['videos']
         self.radio   = kwargs['radio']
         self.Audio   = False
 

--- a/utils.py
+++ b/utils.py
@@ -34,6 +34,7 @@ def read_settings(session, puser=False, ppwd=False):
     user      = __addon__.getSetting('lastfmuser').decode("utf-8")
     pwd       = __addon__.getSetting('lastfmpass').decode("utf-8")
     songs     = __addon__.getSetting('lastfmsubmitsongs') == 'true'
+    videos    = __addon__.getSetting('lastfmsubmitvideos') == 'true'
     radio     = __addon__.getSetting('lastfmsubmitradio') == 'true'
     confirm   = __addon__.getSetting('lastfmconfirm') == 'true'
     sesskey   = __addon__.getSetting('lastfmkey')
@@ -74,6 +75,7 @@ def read_settings(session, puser=False, ppwd=False):
     settings['user']    = user
     settings['pwd']     = pwd
     settings['songs']   = songs
+    settings['videos']  = videos
     settings['radio']   = radio
     settings['confirm'] = confirm
     settings['sesskey'] = sesskey


### PR DESCRIPTION
Adds support for scrobbling musicvideos.

Note:
* Musicvideo scrobbling is disabled by default, and can be enabled in the settings.
* Only videos of type "musicvideo" are scrobbled.
* Requires Leia 18.0-alpha1 (see https://github.com/xbmc/xbmc/pull/13019).